### PR TITLE
linuxbrew

### DIFF
--- a/dotfiles/oh-my-zsh-custom/plugins/homebrew/homebrew.plugin.zsh
+++ b/dotfiles/oh-my-zsh-custom/plugins/homebrew/homebrew.plugin.zsh
@@ -1,5 +1,6 @@
 [ -d "/usr/local/Homebrew" ] && eval "$("/usr/local/Homebrew/bin/brew" shellenv)"
 [ -d "/opt/homebrew" ] && eval "$("/opt/homebrew/bin/brew" shellenv)"
 
+# shellcheck disable=SC2034
 typeset -U path
 export PATH

--- a/dotfiles/oh-my-zsh-custom/plugins/linuxbrew/linuxbrew.plugin.zsh
+++ b/dotfiles/oh-my-zsh-custom/plugins/linuxbrew/linuxbrew.plugin.zsh
@@ -1,9 +1,8 @@
-# From https://docs.brew.sh/Homebrew-on-Linux#install
 export PATH="${HOME}/.rbenv/bin:${PATH}"
 eval "$(rbenv init - zsh)"
 
-test -d "${HOME}/.linuxbrew" && eval "$("${HOME}/.linuxbrew/bin/brew" shellenv)"
-test -d /home/linuxbrew/.linuxbrew && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+[ -d "${HOME}/.linuxbrew" ] && eval "$("${HOME}/.linuxbrew/bin/brew" shellenv)"
+[ -d /home/linuxbrew/.linuxbrew ] && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 
 # shellcheck disable=SC2034
 typeset -U path

--- a/dotfiles/oh-my-zsh-custom/plugins/linuxbrew/linuxbrew.plugin.zsh
+++ b/dotfiles/oh-my-zsh-custom/plugins/linuxbrew/linuxbrew.plugin.zsh
@@ -1,6 +1,10 @@
 # From https://docs.brew.sh/Homebrew-on-Linux#install
+export PATH="${HOME}/.rbenv/bin:${PATH}"
+eval "$(rbenv init - zsh)"
+
 test -d "${HOME}/.linuxbrew" && eval "$("${HOME}/.linuxbrew/bin/brew" shellenv)"
 test -d /home/linuxbrew/.linuxbrew && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 
+# shellcheck disable=SC2034
 typeset -U path
 export PATH

--- a/dotfiles/oh-my-zsh-custom/plugins/linuxbrew/linuxbrew.plugin.zsh
+++ b/dotfiles/oh-my-zsh-custom/plugins/linuxbrew/linuxbrew.plugin.zsh
@@ -1,4 +1,6 @@
-export PATH="${HOME}/.rbenv/bin:${PATH}"
+# Actually *want* path to be split
+# shellcheck disable=2206
+path=("${HOME}/.rbenv/bin" $path)
 eval "$(rbenv init - zsh)"
 
 [ -d "${HOME}/.linuxbrew" ] && eval "$("${HOME}/.linuxbrew/bin/brew" shellenv)"

--- a/script/install-linuxbrew.sh
+++ b/script/install-linuxbrew.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # TODO: make this work for non-Debian distro?
-sudo apt install ruby
+sudo apt -q -y install ruby
 
 # From https://docs.brew.sh/Homebrew-on-Linux#alternative-installation
 if [ ! -d ~/.linuxbrew ]; then

--- a/script/install-linuxbrew.sh
+++ b/script/install-linuxbrew.sh
@@ -36,6 +36,6 @@ if [ ! -d "${HOME}/.linuxbrew" ]; then
   mkdir "${HOME}/.linuxbrew/bin"
   ln -s "${HOME}/.linuxbrew/Homebrew/bin/brew" "${HOME}/.linuxbrew/bin"
 else
-  git -C "${HOME}/.linuxbrew/Homebrew pull"
+  git -C "${HOME}/.linuxbrew/Homebrew" pull
 fi
 eval "$("${HOME}"/.linuxbrew/bin/brew shellenv)"

--- a/script/install-linuxbrew.sh
+++ b/script/install-linuxbrew.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # TODO: make this work for non-Debian distro?
-apt install ruby
+sudo apt install ruby
 
 # From https://docs.brew.sh/Homebrew-on-Linux#alternative-installation
 if [ ! -d ~/.linuxbrew ]; then

--- a/script/install-linuxbrew.sh
+++ b/script/install-linuxbrew.sh
@@ -6,18 +6,36 @@
 # sudo update-locale en_US.UTF-8
 
 # TODO: make this work for non-Debian distro?
-case $(lsb_release --id --short) in
-Raspbian | Debian)
-  sudo apt -q -y install ruby
-  ;;
-esac
+# case $(lsb_release --id --short) in
+# Raspbian | Debian)
+#   sudo apt -q -y install ruby
+#   ;;
+# esac
+
+# Install and update rbenv and Ruby 2.6.3
+if [ ! -d "${HOME}/.rbenv" ]; then
+  git clone https://github.com/rbenv/rbenv.git "${HOME}/.rbenv"
+  export PATH="${HOME}/.rbenv/bin:${PATH}"
+fi
+
+if [ ! -d "${HOME}/.rbenv/plugins/ruby-build" ]; then
+  mkdir -p "${HOME}/.rbenv/plugins"
+  git clone https://github.com/rbenv/ruby-build.git "${HOME}/.rbenv/plugins/ruby-build"
+fi
+
+pushd "${HOME}/.rbenv" || exit
+git pull
+cd "${HOME}/.rbenv/plugins/ruby-build" || exit
+git pull
+popd || exit
+rbenv install 2.6.3
 
 # From https://docs.brew.sh/Homebrew-on-Linux#alternative-installation
-if [ ! -d ~/.linuxbrew ]; then
-  git clone https://github.com/Homebrew/brew ~/.linuxbrew/Homebrew
-  mkdir ~/.linuxbrew/bin
-  ln -s ~/.linuxbrew/Homebrew/bin/brew ~/.linuxbrew/bin
+if [ ! -d "${HOME}/.linuxbrew" ]; then
+  git clone https://github.com/Homebrew/brew "${HOME}/.linuxbrew/Homebrew"
+  mkdir "${HOME}/.linuxbrew/bin"
+  ln -s "${HOME}/.linuxbrew/Homebrew/bin/brew" "${HOME}/.linuxbrew/bin"
 else
-  git -C ~/.linuxbrew/Homebrew pull
+  git -C "${HOME}/.linuxbrew/Homebrew pull"
 fi
-eval "$(~/.linuxbrew/bin/brew shellenv)"
+eval "$("${HOME}"/.linuxbrew/bin/brew shellenv)"

--- a/script/install-linuxbrew.sh
+++ b/script/install-linuxbrew.sh
@@ -1,12 +1,5 @@
 #!/usr/bin/env bash
 
-# On Raspberry Pi, ensure en_US.UTF-8 locale available & installed
-if [ -f /etc/locale.gen ]; then
-  sudo sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/g' /etc/locale.gen
-  sudo locale-gen en_US.UTF-8
-  sudo update-locale en_US.UTF-8
-fi
-
 # TODO: make this work for non-Debian distro?
 case $(lsb_release --id --short) in
 Raspbian | Debian)

--- a/script/install-linuxbrew.sh
+++ b/script/install-linuxbrew.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
 # On Raspberry Pi, ensure en_US.UTF-8 locale available & installed
-# sudo perl -pi -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/g' /etc/locale.gen
-# sudo locale-gen en_US.UTF-8
-# sudo update-locale en_US.UTF-8
+if [ -f /etc/locale.gen ]; then
+  sudo sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/g' /etc/locale.gen
+  sudo locale-gen en_US.UTF-8
+  sudo update-locale en_US.UTF-8
+fi
 
 # TODO: make this work for non-Debian distro?
 case $(lsb_release --id --short) in

--- a/script/install-linuxbrew.sh
+++ b/script/install-linuxbrew.sh
@@ -6,11 +6,11 @@
 # sudo update-locale en_US.UTF-8
 
 # TODO: make this work for non-Debian distro?
-# case $(lsb_release --id --short) in
-# Raspbian | Debian)
-#   sudo apt -q -y install ruby
-#   ;;
-# esac
+case $(lsb_release --id --short) in
+Raspbian | Debian)
+  sudo apt -q -y install libssl-dev libreadline-dev
+  ;;
+esac
 
 # Install and update rbenv and Ruby 2.6.3
 if [ ! -d "${HOME}/.rbenv" ]; then

--- a/script/install-linuxbrew.sh
+++ b/script/install-linuxbrew.sh
@@ -15,8 +15,8 @@ esac
 # Install and update rbenv and Ruby 2.6.3
 if [ ! -d "${HOME}/.rbenv" ]; then
   git clone https://github.com/rbenv/rbenv.git "${HOME}/.rbenv"
-  export PATH="${HOME}/.rbenv/bin:${PATH}"
 fi
+export PATH="${HOME}/.rbenv/bin:${PATH}"
 
 if [ ! -d "${HOME}/.rbenv/plugins/ruby-build" ]; then
   mkdir -p "${HOME}/.rbenv/plugins"

--- a/script/install-linuxbrew.sh
+++ b/script/install-linuxbrew.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 
+# On Raspberry Pi, ensure en_US.UTF-8 locale available & installed
+# sudo perl -pi -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/g' /etc/locale.gen
+# sudo locale-gen en_US.UTF-8
+# sudo update-locale en_US.UTF-8
+
 # TODO: make this work for non-Debian distro?
-sudo apt -q -y install ruby
+case $(lsb_release --id --short) in
+Raspbian | Debian)
+  sudo apt -q -y install ruby
+  ;;
+esac
 
 # From https://docs.brew.sh/Homebrew-on-Linux#alternative-installation
 if [ ! -d ~/.linuxbrew ]; then

--- a/script/install-linuxbrew.sh
+++ b/script/install-linuxbrew.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 
+# TODO: make this work for non-Debian distro?
+apt install ruby
+
 # From https://docs.brew.sh/Homebrew-on-Linux#alternative-installation
-git clone https://github.com/Homebrew/brew ~/.linuxbrew/Homebrew
-mkdir ~/.linuxbrew/bin
-ln -s ~/.linuxbrew/Homebrew/bin/brew ~/.linuxbrew/bin
+if [ ! -d ~/.linuxbrew ]; then
+  git clone https://github.com/Homebrew/brew ~/.linuxbrew/Homebrew
+  mkdir ~/.linuxbrew/bin
+  ln -s ~/.linuxbrew/Homebrew/bin/brew ~/.linuxbrew/bin
+else
+  git -C ~/.linuxbrew/Homebrew pull
+fi
 eval "$(~/.linuxbrew/bin/brew shellenv)"

--- a/script/os-setup
+++ b/script/os-setup
@@ -31,7 +31,7 @@ fi
 [ -z "${SKIP_BUNDLE}" ] && ensure_brewfile_installed
 [ -z "${SKIP_HOME}" ] && ensure_brewfile_installed Brewfile.home
 
-script/extract-onepassword-secrets.sh
+[ -z "${SKIP_SECRETS}" ] && script/extract-onepassword-secrets.sh
 
 # Setup development tools
 script/golang-setup.sh

--- a/script/os-setup
+++ b/script/os-setup
@@ -25,6 +25,13 @@ if is_mac; then
   # install LaunchDaemon to ensure mosh is added to fw allow list
   script/install-fix-mosh.sh
 elif is_linux; then
+  # On Raspberry Pi, ensure en_US.UTF-8 locale available & installed
+  if [ -f /etc/locale.gen ]; then
+    sudo sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/g' /etc/locale.gen
+    sudo locale-gen en_US.UTF-8
+    sudo update-locale en_US.UTF-8
+  fi
+
   script/install-linuxbrew.sh
 fi
 


### PR DESCRIPTION
- Improve install-linuxbrew.sh
- Use sudo to install ruby
- Add check to avoid extracting secrets from 1Password
- Make ruby installation quiet
- More work identifying Linux distro & installing linuxbrew
- Install rbenv & ruby 2.6.3 for linuxbrew
- Fix quote
- Install dependencies for rbenv
- Ensure ~/.rbenv in PATH
- Ensure en_US.UTF-8 locale available on Raspbian hosts
- Move RPi locale setup from intall-linuxbrew.sh to os-setup script
- Cleanup {home,linux}brew plugins
- Cleanup linuxbrew plugin path handling
