### PR TITLE
acourtneybrown/home archiva

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -290,8 +290,8 @@ profiles:
       personal: false
       ssh_agent: ''
     dynvariables:
-      archive_user: op item get k35fj7gqsj5y24cqcagcij6waq --field username
-      archive_password: op item get k35fj7gqsj5y24cqcagcij6waq --field password
+      archiva_user: op item get k35fj7gqsj5y24cqcagcij6waq --field username
+      archiva_password: op item get k35fj7gqsj5y24cqcagcij6waq --field password
       buildbuddy_readwrite_key: op item get BuildBuddy --field "Read+Write API key"
       buildbuddy_dev_ro_key: op item get BuildBuddy --field "textcflt-devprod-test Dev-RO key"
       full_name: op item get 2rou2jbvdvahrl4ov7wtxstdka --fields "first name,last name" | tr ',' ' '

--- a/dotfiles/m2/settings_home.xml
+++ b/dotfiles/m2/settings_home.xml
@@ -13,8 +13,8 @@
   <servers>
     <server>
       <id>archiva.default</id>
-      <username>{{@@ archive_user @@}}</username>
-      <password>{{@@ archive_password @@}}</password>
+      <username>{{@@ archiva_user @@}}</username>
+      <password>{{@@ archiva_password @@}}</password>
     </server>
   </servers>
 


### PR DESCRIPTION
- Add initial ~/.bazelrc file
- Make .bazelrc only user read-write
- Move some config to buildbuddy config
- Add Bazel-related files to global gitignore
- Add clean_bazel_cache function to bazel-custom plugin
- Replace ~ with ${HOME}
- Replace ~ with ${HOME} & use `ct` alias
- Install bazel & tools in personal profile
- Rename clean_bazel_cache to have bazel prefix (& alias with dashes)
- Update to match latest cc-dotfiles templates
- Check for 1 arg to ctcl
- Make ctcl only handle a single argument
- Setup for pushing Python artifacts to local devpi-server (#131)
- Add additional bazel config settings for build
- Don't install tfenv on personla profile
- Enable bazel-remote cache by default
- Add buildbuddy-personal profile
- Flesh out buildbuddy-personal Bazel profile
- Add `buildbuddy-personal` Bazel profile & reorder for overrides
- Add config for local Archiva repository manager
- Export BUILDBUDDY_PERSONAL_KEY in cc-dotfiles plugin
- Rename archiva dynvariables
