### PR TITLE
Add functions to cleanup local GitHub org/user clones

### DIFF
--- a/dotfiles/oh-my-zsh-custom/plugins/git-custom/git-custom.plugin.zsh
+++ b/dotfiles/oh-my-zsh-custom/plugins/git-custom/git-custom.plugin.zsh
@@ -228,3 +228,17 @@ function ghrmarchived() {
     fi
   done
 }
+
+# ghrmdeleted deletes the local clone for any repo that has been deleted on GitHub
+function ghrmdeleted() {
+  for DIR in *; do
+    if [[ -d "${DIR}/.git" ]]; then
+      if ! (cd "$DIR" && gh api --silent "repos/{owner}/{repo}" 2>/dev/null); then
+        echo "removing deleted repo '$DIR'"
+        rm -rf -- "$DIR"
+      fi
+    fi
+  done
+}
+
+alias ghrmremoved='ghrmdeleted; ghrmarchived'

--- a/dotfiles/oh-my-zsh-custom/plugins/git-custom/git-custom.plugin.zsh
+++ b/dotfiles/oh-my-zsh-custom/plugins/git-custom/git-custom.plugin.zsh
@@ -223,7 +223,7 @@ function ghrmarchived() {
       )
       $archived && {
         echo "removing archived repo '$DIR'"
-        rm -rf "$DIR"
+        rm -rf -- "$DIR"
       }
     fi
   done

--- a/dotfiles/oh-my-zsh-custom/plugins/nvm-custom/nvm-custom.plugin.zsh
+++ b/dotfiles/oh-my-zsh-custom/plugins/nvm-custom/nvm-custom.plugin.zsh
@@ -2,7 +2,7 @@
 
 NVM_DIR="${HOME}/.nvm"
 
-if [[ -d ${NVM_DIR} ]]; then
+if command -v nvm && [[ -d ${NVM_DIR} ]]; then
   function nvm_prompt_info() {
     # shellcheck disable=SC2155
     local version="$(nvm current)"


### PR DESCRIPTION
- Fix ghrmarchived to work for repos starting with dash (-)
- Workaround for SentinelOne saying nvm.sh is malware
- Add ghrmdeleted function & ghrmremoved alias
