### PR TITLE
Incorporate change to use `sudo_local`

### DIFF
--- a/script/lib/macos.sh
+++ b/script/lib/macos.sh
@@ -240,7 +240,7 @@ function macos::setup_security() {
       PAM_FILE="/etc/pam.d/sudo_local"
       FIRST_LINE="# sudo_local: local config file which survives system update and is included for sudo"
       if [[ ! -f "/etc/pam.d/sudo_local" ]]; then
-        echo "$FIRST_LINE" | sudo_askpass tee "$PAM_FILE" >/dev/null
+        echo "$FIRST_LINE" | sudo tee "$PAM_FILE" >/dev/null
       fi
     else
       PAM_FILE="/etc/pam.d/sudo"

--- a/script/lib/macos.sh
+++ b/script/lib/macos.sh
@@ -235,8 +235,17 @@ function macos::setup_security() {
   # shellcheck disable=SC2010
   if ls /usr/lib/pam | grep -q "pam_tid.so"; then
     echo "Configuring sudo authentication using TouchID:"
-    PAM_FILE="/etc/pam.d/sudo"
-    FIRST_LINE="# sudo: auth account password session"
+    if [[ -f /etc/pam.d/sudo_local || -f /etc/pam.d/sudo_local.template ]]; then
+      # New in macOS Sonoma, survives updates.
+      PAM_FILE="/etc/pam.d/sudo_local"
+      FIRST_LINE="# sudo_local: local config file which survives system update and is included for sudo"
+      if [[ ! -f "/etc/pam.d/sudo_local" ]]; then
+        echo "$FIRST_LINE" | sudo_askpass tee "$PAM_FILE" >/dev/null
+      fi
+    else
+      PAM_FILE="/etc/pam.d/sudo"
+      FIRST_LINE="# sudo: auth account password session"
+    fi
     if grep -q pam_tid.so "${PAM_FILE}"; then
       echo "ok"
     elif ! head -n1 "${PAM_FILE}" | grep -q "${FIRST_LINE}"; then


### PR DESCRIPTION
Adapted from https://github.com/MikeMcQuaid/strap/pull/831
Using info from https://sixcolors.com/post/2023/08/in-macos-sonoma-touch-id-for-sudo-can-survive-updates/
