### PR TITLE
Use `gh repo clone` in _ghclall

### DIFF
--- a/dotfiles/oh-my-zsh-custom/plugins/git-custom/git-custom.plugin.zsh
+++ b/dotfiles/oh-my-zsh-custom/plugins/git-custom/git-custom.plugin.zsh
@@ -235,7 +235,7 @@ function _ghclall() {
   collection="${1}"
   entity="${2}"
 
-  gh api "${collection}/${entity}/repos" --paginate --jq '.[] | select(.archived == false) | .full_name' | xargs -n 1 -I % -P 6 -t git clone gh:%
+  gh api "${collection}/${entity}/repos" --paginate --jq '.[] | select(.archived == false) | .full_name' | xargs -n 1 -I % -P 6 -t gh repo clone %
 }
 
 # ghclorg clones all of the non-archived repos under a GitHub org


### PR DESCRIPTION
Ensures that the `set-default` value is initialized for forked repos.  Without this
subsequent `gh api` & `gh repo` commands would complain and fail to work as previously
expected.
