### PR TITLE
Direct 1Password links to appropriate Firefox profile

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -250,12 +250,20 @@ profiles:
       firefox_jenny_ids: |
         op item list --categories Login --format=json |
           op item get - --format=json |
-          jq -r "select(.fields.[] | select(.id == \"username\") | .value | test(\"`{{@@ jenny_email_acct @@}}`\")) | .id" 2>/dev/null |
+          jq -r "
+              select(
+                     (.fields.[] | select(.id == \"username\") | .value | contains(\"`{{@@ jenny_email_acct @@}}`\")) or
+                     (.title | contains(\"Jenny\"))
+                    ) | .id" 2>/dev/null |
           sort
       firefox_joint_ids: |
         op item list --categories Login --format=json |
           op item get - --format=json |
-          jq -r "select(.fields.[] | select(.id == \"username\") | .value | test(\"`{{@@ joint_email_acct @@}}`\")) | .id" 2>/dev/null |
+          jq -r "
+              select(
+                     (.fields.[] | select(.id == \"username\") | .value | contains(\"`{{@@ joint_email_acct @@}}`\")) or
+                     (.title | contains(\"Joint\"))
+                    ) | .id" 2>/dev/null |
           sort
       full_name: op item get 7ewiekzrvxiwjkwmfhl2646ynq --fields "first name,last name" | tr ',' ' '
       gh_cli_token: op item get "GitHub" --fields "gh cli token"

--- a/config.yaml
+++ b/config.yaml
@@ -244,7 +244,19 @@ profiles:
       personal: false
       ssh_agent: ''
     dynvariables:
-      firefox_me_ids: op item list --tags Firefox:Me --format=json | jq '.[].id' | sort
+      firefox_all_ids: op item list --categories Login --format=json | jq -r '.[].id' | sort
+      firefox_cara_ids: op item list --vault Cara --categories Login --format=json | jq -r '.[].id' | sort
+      firefox_cb_ids: op item list --vault Carter --categories Login --format=json | jq -r '.[].id' | sort
+      firefox_jenny_ids: |
+        op item list --categories Login --format=json |
+          op item get - --format=json |
+          jq -r "select(.fields.[] | select(.id == \"username\") | .value | test(\"`{{@@ jenny_email_acct @@}}`\")) | .id" 2>/dev/null |
+          sort
+      firefox_joint_ids: |
+        op item list --categories Login --format=json |
+          op item get - --format=json |
+          jq -r "select(.fields.[] | select(.id == \"username\") | .value | test(\"`{{@@ joint_email_acct @@}}`\")) | .id" 2>/dev/null |
+          sort
       full_name: op item get 7ewiekzrvxiwjkwmfhl2646ynq --fields "first name,last name" | tr ',' ' '
       gh_cli_token: op item get "GitHub" --fields "gh cli token"
       gitea_maven_token: op item get "Gitea (acourtneybrown)" --field "Maven token"
@@ -256,6 +268,8 @@ profiles:
       gitlab_account: op item get "GitLab" --field username
       glab_cli_token: op item get "GitLab" --field "glab cli token"
       homebrew_prefix: brew --prefix
+      jenny_email_acct: op item get mw5zoqbzxjfp3ccmx7wcv52lsi --fields email | sed 's/\([^+@]*\).*/\1/'
+      joint_email_acct: op item get 2rou2jbvdvahrl4ov7wtxstdka --fields email | sed 's/\([^+@]*\).*/\1/'
       personal_email: op item get 7ewiekzrvxiwjkwmfhl2646ynq --field email
       personal_public_key: op item get "Default key" --field "public key"
       sublime_text_license: op item get "Sublime Text 4+" --field "license key"

--- a/dotfiles/finicky.js
+++ b/dotfiles/finicky.js
@@ -6,37 +6,7 @@ function openInFirefoxContainer(containerName, urlString) {
   )}`;
 }
 
-function contains1pId(urlSearch) {
-  for (const id of meContainerIds) {
-    if (urlSearch.includes(`${id}=${id}`)) {
-      return true
-    }
-  }
-  return false
-}
-
-function remove1pId(urlString) {
-  result = urlString
-  for (const regex of meUrlSearchRegex) {
-    result = result.replace(regex, "")
-  }
-  return result
-}
-
-const noContainerHosts = new Set(['duckduckgo.com', 'www.google.com', 'www.amazon.com', 'wikipedia.org'])
-const bundleIdsFor1p = new Set(["com.agilebits.onepassword7", "com.1password.1password"])
 const bundleIdsForHarmony = new Set(["com.logitech.myharmony"])
-const bundleIdsForAlfred = new Set(["com.runningwithcrayons.Alfred"])
-const meContainerIds = [
-  {%@@ for id in firefox_me_ids.split() @@%}
-    {{@@ id @@}},
-  {%@@ endfor @@%}
-]
-const meUrlSearchRegex = [
-  {%@@ for id in firefox_me_ids.split() @@%}
-    new RegExp("[?&]?" + {{@@ id @@}} + "=" + {{@@ id @@}}),
-  {%@@ endfor @@%}
-]
 
 module.exports = {
   defaultBrowser: "Firefox",
@@ -76,9 +46,13 @@ module.exports = {
         /^https:\/\/github\.com\/NotCharlie(\/|$)/,
 
         "https://www.amazon.com/alexa-privacy/apd/rvh",
+
+        ({ opener }) => {
+          return bundleIdsForHarmony.has(opener.bundleId)
+        },
       ],
       url: ({ urlString }) => {
-        return openInFirefoxContainer("Me", remove1pId(urlString));
+        return openInFirefoxContainer("Me", urlString);
       },
       browser: "Firefox",
     },
@@ -98,22 +72,56 @@ module.exports = {
     {%@@ if personal @@%}
     {
       match: [
-        ({ opener, url }) => {
-          if (bundleIdsFor1p.has(opener.bundleId)) {
-            return true
-          }
-          if (bundleIdsForHarmony.has(opener.bundleId)) {
-            return true
-          }
-
-          if (bundleIdsForAlfred.has(opener.bundleId)) {
-            return !noContainerHosts.has(url.host) || contains1pId(url.search)
-          }
-          return false
-        },
+        {%@@ for id in firefox_cara_ids.split() @@%}
+          /{{@@ id @@}}={{@@ id @@}}/,
+        {%@@ endfor @@%}
       ],
       url: ({ urlString }) => {
-        return openInFirefoxContainer("Me", remove1pId(urlString));
+        return openInFirefoxContainer("Cara", urlString);
+      },
+      browser: "Firefox",
+    },
+    {
+      match: [
+        {%@@ for id in firefox_cb_ids.split() @@%}
+          /{{@@ id @@}}={{@@ id @@}}/,
+        {%@@ endfor @@%}
+      ],
+      url: ({ urlString }) => {
+        return openInFirefoxContainer("Carter", urlString);
+      },
+      browser: "Firefox",
+    },
+    {
+      match: [
+        {%@@ for id in firefox_joint_ids.split() @@%}
+          /{{@@ id @@}}={{@@ id @@}}/,
+        {%@@ endfor @@%}
+      ],
+      url: ({ urlString }) => {
+        return openInFirefoxContainer("Joint", urlString);
+      },
+      browser: "Firefox",
+    },
+    {
+      match: [
+        {%@@ for id in firefox_jenny_ids.split() @@%}
+          /{{@@ id @@}}={{@@ id @@}}/,
+        {%@@ endfor @@%}
+      ],
+      url: ({ urlString }) => {
+        return openInFirefoxContainer("Jenny", urlString);
+      },
+      browser: "Firefox",
+    },
+    {
+      match: [
+        {%@@ for id in firefox_all_ids.split() @@%}
+          /{{@@ id @@}}={{@@ id @@}}/,
+        {%@@ endfor @@%}
+      ],
+      url: ({ urlString }) => {
+        return openInFirefoxContainer("Me", urlString);
       },
       browser: "Firefox",
     },


### PR DESCRIPTION
Direct urls from Alfred (including the `id=id` query param) to the "Me" profile

Add handling for "joint" & "jenny" profiles

Using combo of `dynvariables` to look for logins with the username
matching the `joint` email account (not includeing plus-address or
host) or matching Jenny's email account & direct them to the appropriate
Firefox container profile.
