### PR TITLE
Only load `alfred-workflow-dev` plugin on Mac

### DIFF
--- a/dotfiles/oh-my-zsh-custom/plugins/1password-custom/1password-custom.plugin.zsh
+++ b/dotfiles/oh-my-zsh-custom/plugins/1password-custom/1password-custom.plugin.zsh
@@ -37,3 +37,16 @@ function op-check-vault() {
               (.fields.[] | select(.id == \"username\") | .value | contains(\"$username\"))) and
              (.tags | contains([\"WrongVaultOk\"]) | not)) | .id"
 }
+
+# op-ssh-keygen-sign signs the specified string, using an SSH key obtained from
+# the ssh-agent (default: the `host_ssh_key_name` from config.yaml for this host)
+function op-ssh-keygen-sign() {
+  [[ $# -gt 0 ]] || {
+    echo "Usage: $0 <to_sign> [ <ssh key name> ]"
+    return 1
+  }
+  local to_sign=$1
+  local key=${2:-{{@@ host_ssh_key_name @@}}}
+
+  echo -n "$to_sign" | ssh-keygen -Y sign -n gitea -f <(op read "op://Private/$key/public key")
+}

--- a/dotfiles/zshrc
+++ b/dotfiles/zshrc
@@ -86,7 +86,6 @@ ZSH_CUSTOM="${HOME}/.oh-my-zsh-custom"
 plugins=(
   1password
   1password-custom
-  alfred-workflow-dev
   aliases
   bazel
   bazel-custom
@@ -124,6 +123,7 @@ plugins=(
   evalcache
 
   {%@@ if mac @@%}
+  alfred-workflow-dev
   homebrew
   iterm2
   iterm2-custom


### PR DESCRIPTION
- **Add op-ssh-keygen-sign function to custom 1Password plugin**
- **Only load `alfred-workflow-dev` plugin on Mac**
