### PR TITLE
Differentiate between personal & public Gitea servers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -335,14 +335,17 @@ profiles:
       ssh_agent_lifetime: 1h
       host_password: unset
       host_ssh_key_name: Default key
-      gitea_tea_token: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/token"
+      gitea.com_tea_token: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/3evxc47vgvyz4w65n6krlpq25u/token"
+      gitea.notcharlie.com_tea_token: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/token"
+      gitea_hosts: "gitea.com gitea.notcharlie.com"
     dynvariables:
       authorized_keys: op item list --tags allow-ssh --format=json | op item get - --field "public key" | sort | uniq
       full_name: op item get 6jjizlkc5bstuors76ickhd7fa --fields "first name,last name" | tr ',' ' '
-      gitea_maven_token: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/Tokens/Maven token"
-      gitea_pypi_token: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/Tokens/PyPI token"
-      gitea_username: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/email"
-      gitea_website: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/host address"
+      gitea.com_username: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/3evxc47vgvyz4w65n6krlpq25u/user_name"
+      gitea.notcharlie.com_maven_token: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/Tokens/Maven token"
+      gitea.notcharlie.com_pypi_token: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/Tokens/PyPI token"
+      gitea.notcharlie.com_username: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/email"
+      gitea.notcharlie.com_website: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/host address"
       github_account: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/GitHub/login"
       github_netrc_token: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/GitHub/Section_E346B352A4E54313BBD97E6B371DF8FF/netrc"
       github_signing_key: op read "op://Private/{{@@ host_ssh_key_name @@}}/public key"

--- a/config.yaml
+++ b/config.yaml
@@ -338,11 +338,6 @@ profiles:
     dynvariables:
       authorized_keys: op item list --tags allow-ssh --format=json | op item get - --field "public key" | sort | uniq
       full_name: op item get 6jjizlkc5bstuors76ickhd7fa --fields "first name,last name" | tr ',' ' '
-      gitea.com_username: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/3evxc47vgvyz4w65n6krlpq25u/user_name"
-      gitea.notcharlie.com_maven_token: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/Tokens/Maven token"
-      gitea.notcharlie.com_pypi_token: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/Tokens/PyPI token"
-      gitea.notcharlie.com_username: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/email"
-      gitea.notcharlie.com_website: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/host address"
       github_account: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/GitHub/login"
       github_netrc_token: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/GitHub/Section_E346B352A4E54313BBD97E6B371DF8FF/netrc"
       github_signing_key: op read "op://Private/{{@@ host_ssh_key_name @@}}/public key"
@@ -350,6 +345,12 @@ profiles:
       homebrew_prefix: brew --prefix
       joint_google_account: op read "op://Joint/hqlcejuk5jil2e6hmmklzahub4/Email"
       personal_email: op read "op://Adam/6jjizlkc5bstuors76ickhd7fa/Internet Details/email"
+      personal_gitea_maven_token: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/Tokens/Maven token"
+      personal_gitea_hostname: "{{@@ personal_gitea_website @@}} | sed 's|https://||'"
+      personal_gitea_pypi_token: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/Tokens/PyPI token"
+      personal_gitea_username: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/email"
+      personal_gitea_website: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/host address"
+      public_gitea_username: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/3evxc47vgvyz4w65n6krlpq25u/user_name"
       sublime_text_license: op read "op://Adam/lewokobsx23vb6ncwce457sdvy/license key"
       synology_api_account: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/glpg6ggd6hstlznvzdxfwbgzfm/username"
       synology_api_password: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/glpg6ggd6hstlznvzdxfwbgzfm/password"

--- a/config.yaml
+++ b/config.yaml
@@ -335,9 +335,6 @@ profiles:
       ssh_agent_lifetime: 1h
       host_password: unset
       host_ssh_key_name: Default key
-      gitea.com_tea_token: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/3evxc47vgvyz4w65n6krlpq25u/token"
-      gitea.notcharlie.com_tea_token: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/token"
-      gitea_hosts: "gitea.com gitea.notcharlie.com"
     dynvariables:
       authorized_keys: op item list --tags allow-ssh --format=json | op item get - --field "public key" | sort | uniq
       full_name: op item get 6jjizlkc5bstuors76ickhd7fa --fields "first name,last name" | tr ',' ' '

--- a/dotfiles/config/pip/pip.conf
+++ b/dotfiles/config/pip/pip.conf
@@ -1,2 +1,2 @@
 [global]
-extra-index-url = https://{{@@ gitea_username @@}}:{{@@ gitea_pypi_token @@}}@gitea.notcharlie.com/api/packages/{{@@ gitea_username @@}}/pypi/simple
+extra-index-url = https://{{@@ _vars['gitea.notcharlie.com_username'] @@}}:{{@@ _vars['gitea.notcharlie.com_pypi_token'] @@}}@gitea.notcharlie.com/api/packages/{{@@ _vars['gitea.notcharlie.com_username'] @@}}/pypi/simple

--- a/dotfiles/config/pip/pip.conf
+++ b/dotfiles/config/pip/pip.conf
@@ -1,2 +1,2 @@
 [global]
-extra-index-url = https://{{@@ _vars['gitea.notcharlie.com_username'] @@}}:{{@@ _vars['gitea.notcharlie.com_pypi_token'] @@}}@gitea.notcharlie.com/api/packages/{{@@ _vars['gitea.notcharlie.com_username'] @@}}/pypi/simple
+extra-index-url = https://{{@@ personal_gitea_username @@}}:{{@@ personal_gitea_pypi_token @@}}@{{@@ personal_gitea_hostname @@}}/api/packages/{{@@ personal_gitea_username @@}}/pypi/simple

--- a/dotfiles/docker/config.json
+++ b/dotfiles/docker/config.json
@@ -1,11 +1,11 @@
 {
 	"auths": {
-		"gitea.notcharlie.com": {},
+		"{{@@ personal_gitea_hostname @@}}": {},
 		"index.docker.io": {}
 	},
 	"credsStore": "1password",
 	"credHelpers": {
-		"gitea.notcharlie.com": "1password",
+		"{{@@ personal_gitea_hostname @@}}": "1password",
 		"index.docker.io": "1password"
 	},
 	"currentContext": "desktop-linux",

--- a/dotfiles/finicky.js
+++ b/dotfiles/finicky.js
@@ -94,7 +94,7 @@ export default {
         ]),
 
         /^https:\/\/calendly\.com\/omaras\//,
-        /^https:\/\/gitea\.com\/{{@@ gitea_username @@}}(\/|$)/,
+        /^https:\/\/gitea\.com\/{{@@ _vars['gitea.com_username'] @@}}(\/|$)/,
         /^https:\/\/github\.com\/{{@@ github_account @@}}(\/|$)/,
         /^https:\/\/github\.com\/NotCharlie(\/|$)/,
         /^https:\/\/gitlab\.com\/{{@@ gitlab_account @@}}(\/|$)/,

--- a/dotfiles/finicky.js
+++ b/dotfiles/finicky.js
@@ -1,4 +1,4 @@
-// See https://github.com/johnste/finicky/wiki/Configuration-(v3)
+// See https://github.com/johnste/finicky/wiki/Configuration-(v4)
 
 function openInFirefoxContainer(containerName, url) {
   // console.log('opening in ' + containerName);
@@ -91,10 +91,11 @@ export default {
           "notcharlie.slack.com",
           "pbj-dogs.slack.com",
           "xooglerco.slack.com",
+          "{{@@ personal_gitea_hostname @@}}",
         ]),
 
         /^https:\/\/calendly\.com\/omaras\//,
-        /^https:\/\/gitea\.com\/{{@@ _vars['gitea.com_username'] @@}}(\/|$)/,
+        /^https:\/\/gitea\.com\/{{@@ public_gitea_username @@}}(\/|$)/,
         /^https:\/\/github\.com\/{{@@ github_account @@}}(\/|$)/,
         /^https:\/\/github\.com\/NotCharlie(\/|$)/,
         /^https:\/\/gitlab\.com\/{{@@ gitlab_account @@}}(\/|$)/,

--- a/dotfiles/gitconfig-shorteners
+++ b/dotfiles/gitconfig-shorteners
@@ -32,9 +32,9 @@
 
 	insteadOf = "gla:"
 
-[url "ssh://git@gitea.notcharlie.com/"]
+[url "ssh://git@{{@@ personal_gitea_hostname @@}}/"]
 
 	insteadOf = "gth:"
 	insteadOf = "giteahome:"
-	insteadOf = "git://gitea.notcharlie.com/"
-	insteadOf = https://gitea.notcharlie.com/
+	insteadOf = "git://{{@@ personal_gitea_hostname @@}}/"
+	insteadOf = {{@@ personal_gitea_website @@}}/

--- a/dotfiles/gitconfig-shorteners
+++ b/dotfiles/gitconfig-shorteners
@@ -38,3 +38,14 @@
 	insteadOf = "giteahome:"
 	insteadOf = "git://{{@@ personal_gitea_hostname @@}}/"
 	insteadOf = {{@@ personal_gitea_website @@}}/
+
+[url "ssh://git@{{@@ personal_gitea_hostname @@}}/{{@@ personal_gitea_username @@}}/"]
+
+	insteadOf = "gtha:"
+
+[url "ssh://git@gitea.com/"]
+
+	insteadOf = "gt:"
+	insteadOf = "gitea:"
+	insteadOf = "git://gitea.com/"
+	insteadOf = https://gitea.com/

--- a/dotfiles/gitconfig-shorteners
+++ b/dotfiles/gitconfig-shorteners
@@ -49,3 +49,7 @@
 	insteadOf = "gitea:"
 	insteadOf = "git://gitea.com/"
 	insteadOf = https://gitea.com/
+
+[url "ssh://git@gitea.com/{{@@ public_gitea_username @@}}/"]
+
+	insteadOf = "gta:"

--- a/dotfiles/m2/settings_home.xml
+++ b/dotfiles/m2/settings_home.xml
@@ -9,7 +9,7 @@
         <httpHeaders>
           <property>
             <name>Authorization</name>
-            <value>token {{@@ _vars['gitea.notcharlie.com_maven_token'] @@}}</value>
+            <value>token {{@@ personal_gitea_maven_token @@}}</value>
           </property>
         </httpHeaders>
       </configuration>
@@ -25,7 +25,7 @@
       <repositories>
         <repository>
           <id>gitea</id>
-          <url>{{@@ _vars['gitea.notcharlie.com_website'] @@}}/api/packages/{{@@ _vars['gitea.notcharlie.com_username'] @@}}/maven</url>
+          <url>{{@@ personal_gitea_website @@}}/api/packages/{{@@ personal_gitea_username @@}}/maven</url>
           <releases>
             <enabled>true</enabled>
           </releases>

--- a/dotfiles/m2/settings_home.xml
+++ b/dotfiles/m2/settings_home.xml
@@ -9,7 +9,7 @@
         <httpHeaders>
           <property>
             <name>Authorization</name>
-            <value>token {{@@ gitea_maven_token @@}}</value>
+            <value>token {{@@ _vars['gitea.notcharlie.com_maven_token'] @@}}</value>
           </property>
         </httpHeaders>
       </configuration>
@@ -25,7 +25,7 @@
       <repositories>
         <repository>
           <id>gitea</id>
-          <url>{{@@ gitea_website @@}}/api/packages/{{@@ gitea_username @@}}/maven</url>
+          <url>{{@@ _vars['gitea.notcharlie.com_website'] @@}}/api/packages/{{@@ _vars['gitea.notcharlie.com_username'] @@}}/maven</url>
           <releases>
             <enabled>true</enabled>
           </releases>

--- a/dotfiles/pypirc_home
+++ b/dotfiles/pypirc_home
@@ -1,7 +1,7 @@
 [distutils]
-index-servers = gitea
+index-servers = gitea.notcharlie.com
 
-[gitea]
-repository = {{@@ gitea_website @@}}/api/packages/{{@@ gitea_username @@}}/pypi
-username = {{@@ gitea_username @@}}
-password = {{@@ gitea_pypi_token @@}}
+[gitea.notcharlie.com]
+repository = {{@@ _vars['gitea.notcharlie.com_website'] @@}}/api/packages/{{@@ _vars['gitea.notcharlie.com_username'] @@}}/pypi
+username = {{@@ _vars['gitea.notcharlie.com_username'] @@}}
+password = {{@@ _vars['gitea.notcharlie.com_pypi_token'] @@}}

--- a/dotfiles/pypirc_home
+++ b/dotfiles/pypirc_home
@@ -1,7 +1,7 @@
 [distutils]
-index-servers = gitea.notcharlie.com
+index-servers = personal_gitea
 
-[gitea.notcharlie.com]
-repository = {{@@ _vars['gitea.notcharlie.com_website'] @@}}/api/packages/{{@@ _vars['gitea.notcharlie.com_username'] @@}}/pypi
-username = {{@@ _vars['gitea.notcharlie.com_username'] @@}}
-password = {{@@ _vars['gitea.notcharlie.com_pypi_token'] @@}}
+[personal_gitea]
+repository = {{@@ personal_gitea_website @@}}/api/packages/{{@@ personal_gitea_username @@}}/pypi
+username = {{@@ personal_gitea_username @@}}
+password = {{@@ personal_gitea_pypi_token @@}}

--- a/dotfiles/zshenv
+++ b/dotfiles/zshenv
@@ -13,6 +13,16 @@ if [[ "$alfred_workflow_name" == "GitLabFred" ]]; then
 fi
 
 if [[ "$alfred_workflow_name" == "GiteaFred" ]]; then
-	GITEA_SERVER_TOKEN=$({{@@ gitea_tea_token @@}})
+	# declare -A gitea_token_for
+	# {%@@ for host in gitea_hosts.split() @@%}
+	# gitea_token_for[{{@@ host @@}}]=$({{@@ _vars[host ~ "_tea_token"] @@}})
+	# {%@@ endfor @@%}
+	# GITEA_SERVER_TOKEN=$gitea_token_for[$gitea_host]
+	# export GITEA_SERVER_TOKEN
+
+	{%@@ for host in gitea_hosts.split() @@%}
+	gitea_token_for_{{@@ host @@}}=$({{@@ _vars[host ~ "_tea_token"] @@}})
+	{%@@ endfor @@%}
+	GITEA_SERVER_TOKEN=$(eval \$gitea_token_for_$gitea_host)
 	export GITEA_SERVER_TOKEN
 fi

--- a/dotfiles/zshenv
+++ b/dotfiles/zshenv
@@ -13,16 +13,9 @@ if [[ "$alfred_workflow_name" == "GitLabFred" ]]; then
 fi
 
 if [[ "$alfred_workflow_name" == "GiteaFred" ]]; then
-	# declare -A gitea_token_for
-	# {%@@ for host in gitea_hosts.split() @@%}
-	# gitea_token_for[{{@@ host @@}}]=$({{@@ _vars[host ~ "_tea_token"] @@}})
-	# {%@@ endfor @@%}
-	# GITEA_SERVER_TOKEN=$gitea_token_for[$gitea_host]
-	# export GITEA_SERVER_TOKEN
-
-	{%@@ for host in gitea_hosts.split() @@%}
-	gitea_token_for_{{@@ host @@}}=$({{@@ _vars[host ~ "_tea_token"] @@}})
-	{%@@ endfor @@%}
-	GITEA_SERVER_TOKEN=$(eval \$gitea_token_for_$gitea_host)
+    # shellcheck disable=SC2154
+    GITEA_SERVER_TOKEN=$(op item list --tags gitea-token --format=json | op item get - --format=json |
+      jq -r "select(.fields.[] | select(.label == \"host address\") | .value | contains(\"$gitea_host\"))
+             | .fields.[] | select(.label == \"token\") | .value")
 	export GITEA_SERVER_TOKEN
 fi


### PR DESCRIPTION
- **Initial pass at allowing different token for Alfred workflow based on hostname**
- **Remove `GITEA_SERVER_TOKEN`-related variables**
- **Find `GITEA_SERVER_TOKEN` by looking for `gitea-token`-tagged entries with matching "host address"**
- **Replace `gitea.notcharlie.com*` variables with `personal_gitea...` ones**
