### PR TITLE
Install Docker via `apt` (not `brew`)

### DIFF
--- a/script/lib/profile.sh
+++ b/script/lib/profile.sh
@@ -74,6 +74,9 @@ function profile::linux() {
   sudo apt install -qy make build-essential libssl-dev zlib1g-dev \
     libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
     libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+
+  sudo apt install -qy docker.io
+  sudo adduser "$(whoami)" docker
 }
 
 function profile::synology_dsm() {

--- a/script/lib/resources/Brewfile.linux
+++ b/script/lib/resources/Brewfile.linux
@@ -1,4 +1,3 @@
 brew "bazelisk"
 brew "buildifier"
 brew "buildozer"
-brew "docker"


### PR DESCRIPTION
It looks like the Homebrew `docker` package only contains the client CLI,
not the server daemon.
