### PR TITLE
Remove `python-vipaccess` from `pipx`-installed items

### DIFF
--- a/script/lib/profile.sh
+++ b/script/lib/profile.sh
@@ -45,7 +45,7 @@ function profile::personal() {
   profile::enable_pyenv
   profile::enable_goenv
 
-  profile::pipx_install 3.13 python-kasa python-vipaccess tox twine pytest build poetry
+  profile::pipx_install 3.13 python-kasa tox twine pytest build poetry
 }
 
 function profile::linux() {


### PR DESCRIPTION
Fidelity has moved away from Symnatec VIP Access as of mid-2025, so it's no
longer necessary to have installed.
