### PR TITLE
Revert "Move `default` variables into top-level dict"

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -255,8 +255,8 @@ profiles:
       alfred_preferences_localhash: "f10f132bffbde36d011dcf6644f262cf3d810ce7"
     include:
       - mac
-      - personal_mac
       - dev_mac
+      - personal_mac
   adams-mbp.local:
     include:
       - adams-mbp

--- a/config.yaml
+++ b/config.yaml
@@ -35,34 +35,6 @@ config:
   cmpignore:
     - .DS_Store
     - .localized
-variables:
-  linux: false
-  mac: false
-  synology_dsm: false
-  personal: false
-  songchro_file_music_root: /music
-  ssh_agent: ''
-  ssh_agent_lifetime: 1h
-  host_password: unset
-  host_ssh_key_name: Default key
-dynvariables:
-  authorized_keys: op item list --tags allow-ssh --format=json | op item get - --field "public key" | sort | uniq
-  full_name: op item get 6jjizlkc5bstuors76ickhd7fa --fields "first name,last name" | tr ',' ' '
-  github_account: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/GitHub/login"
-  github_netrc_token: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/GitHub/Section_E346B352A4E54313BBD97E6B371DF8FF/netrc"
-  gitlab_account: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/GitLab/username"
-  homebrew_prefix: brew --prefix
-  joint_google_account: op read "op://Joint/hqlcejuk5jil2e6hmmklzahub4/Email"
-  personal_email: op read "op://Adam/6jjizlkc5bstuors76ickhd7fa/Internet Details/email"
-  personal_gitea_hostname: "{{@@ personal_gitea_website @@}} | sed 's|https://||'"
-  personal_gitea_username: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/email"
-  personal_gitea_website: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/host address"
-  plex_baseurl: op read "op://Songchro/Plex/hostname"
-  plex_token: op read "op://Songchro/Plex/credential"
-  public_gitea_username: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/3evxc47vgvyz4w65n6krlpq25u/user_name"
-  sublime_text_license: op read "op://Adam/lewokobsx23vb6ncwce457sdvy/license key"
-  synology_api_account: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/glpg6ggd6hstlznvzdxfwbgzfm/username"
-  synology_api_password: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/glpg6ggd6hstlznvzdxfwbgzfm/password"
 dotfiles:
   d_bin:
     src: bin
@@ -404,6 +376,34 @@ profiles:
     variables:
       synology_dsm: true
   default:
+    variables:
+      linux: false
+      mac: false
+      synology_dsm: false
+      personal: false
+      songchro_file_music_root: /music
+      ssh_agent: ''
+      ssh_agent_lifetime: 1h
+      host_password: unset
+      host_ssh_key_name: Default key
+    dynvariables:
+      authorized_keys: op item list --tags allow-ssh --format=json | op item get - --field "public key" | sort | uniq
+      full_name: op item get 6jjizlkc5bstuors76ickhd7fa --fields "first name,last name" | tr ',' ' '
+      github_account: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/GitHub/login"
+      github_netrc_token: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/GitHub/Section_E346B352A4E54313BBD97E6B371DF8FF/netrc"
+      gitlab_account: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/GitLab/username"
+      homebrew_prefix: brew --prefix
+      joint_google_account: op read "op://Joint/hqlcejuk5jil2e6hmmklzahub4/Email"
+      personal_email: op read "op://Adam/6jjizlkc5bstuors76ickhd7fa/Internet Details/email"
+      personal_gitea_hostname: "{{@@ personal_gitea_website @@}} | sed 's|https://||'"
+      personal_gitea_username: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/email"
+      personal_gitea_website: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/host address"
+      plex_baseurl: op read "op://Songchro/Plex/hostname"
+      plex_token: op read "op://Songchro/Plex/credential"
+      public_gitea_username: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/3evxc47vgvyz4w65n6krlpq25u/user_name"
+      sublime_text_license: op read "op://Adam/lewokobsx23vb6ncwce457sdvy/license key"
+      synology_api_account: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/glpg6ggd6hstlznvzdxfwbgzfm/username"
+      synology_api_password: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/glpg6ggd6hstlznvzdxfwbgzfm/password"
     dotfiles:
       - d_bin
       - d_config_1Password


### PR DESCRIPTION
This reverts commit b18edbdefe033051fb43a00f6243cc729dca8ef5.

Removes workaround for https://github.com/deadc0de6/dotdrop/issues/469
