### PR TITLE
Fix 1Password `op read` refs after vault moves

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -271,7 +271,7 @@ profiles:
       - linux
       - linux_dev
     variables:
-      host_password: "op://Home network/beelink.notcharlie.com/password"
+      host_password: op://Home network/beelink.notcharlie.com/password
       host_ssh_key_name: beelink key
       songchro_file_music_root: ~/synology/music
       ssh_agent_lifetime: 12h
@@ -290,7 +290,7 @@ profiles:
     include:
       - synology_dsm
     variables:
-      host_password: "op://Home network/4fwv2ypyyuqba2mzxbtizwm7s4/password"
+      host_password: op://Home network/4fwv2ypyyuqba2mzxbtizwm7s4/password
       host_ssh_key_name: synology key
       songchro_file_music_root: /volume13/music
       ssh_agent_lifetime: 12h
@@ -300,7 +300,7 @@ profiles:
       - linux_dev
     variables:
       host_ssh_key_name: pve-docker key
-      host_password: "op://Home network/pun7qwv2tcg54nqlkeysiexnjy/password"
+      host_password: op://Home network/pun7qwv2tcg54nqlkeysiexnjy/password
   mac:
     dynvariables:
       alfred_workflow_service_account_token: op read "op://Service Account Tokens/Alfred Workflows/credential"

--- a/config.yaml
+++ b/config.yaml
@@ -271,13 +271,13 @@ profiles:
       - linux
       - linux_dev
     variables:
-      host_password: op://jrew5nqtk5aqdgupcoxqjuevwu/beelink.notcharlie.com/password
+      host_password: "op://Home network/beelink.notcharlie.com/password"
       host_ssh_key_name: beelink key
       songchro_file_music_root: ~/synology/music
       ssh_agent_lifetime: 12h
     dynvariables:
-      synology_username: op read "op://Adam/m77teghqv2ec7xttb47j3qchsa/username"
-      synology_password: op read "op://Adam/m77teghqv2ec7xttb47j3qchsa/password"
+      synology_username: op read "op://Home network/4fwv2ypyyuqba2mzxbtizwm7s4/username"
+      synology_password: op read "op://Home network/4fwv2ypyyuqba2mzxbtizwm7s4/password"
     dotfiles:
       - d_smbcredentials
   beelink.local:
@@ -290,7 +290,7 @@ profiles:
     include:
       - synology_dsm
     variables:
-      host_password: op://Adam/m77teghqv2ec7xttb47j3qchsa/password
+      host_password: "op://Home network/4fwv2ypyyuqba2mzxbtizwm7s4/password"
       host_ssh_key_name: synology key
       songchro_file_music_root: /volume13/music
       ssh_agent_lifetime: 12h
@@ -300,7 +300,7 @@ profiles:
       - linux_dev
     variables:
       host_ssh_key_name: pve-docker key
-      host_password: op://jrew5nqtk5aqdgupcoxqjuevwu/af3cwox6m6su5jkzo4xyt7n4ae/password
+      host_password: "op://Home network/pun7qwv2tcg54nqlkeysiexnjy/password"
   mac:
     dynvariables:
       alfred_workflow_service_account_token: op read "op://Service Account Tokens/Alfred Workflows/credential"
@@ -406,16 +406,16 @@ profiles:
       joint_google_account: op read "op://Joint/hqlcejuk5jil2e6hmmklzahub4/Email"
       personal_email: op read "op://Adam/6jjizlkc5bstuors76ickhd7fa/Internet Details/email"
       personal_gitea_hostname: "{{@@ personal_gitea_website @@}} | sed 's|https://||'"
-      personal_gitea_maven_token: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/Tokens/Maven token"
-      personal_gitea_pypi_token: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/Tokens/PyPI token"
-      personal_gitea_username: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/email"
-      personal_gitea_website: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/44cpfo43uza4dguc5l52zcl6ku/host address"
+      personal_gitea_maven_token: op read "op://Home network/xyzrcfuukvvg35dyyawz55d7j4/Tokens/Maven token"
+      personal_gitea_pypi_token: op read "op://Home network/xyzrcfuukvvg35dyyawz55d7j4/Tokens/PyPI token"
+      personal_gitea_username: op read "op://Home network/xyzrcfuukvvg35dyyawz55d7j4/email"
+      personal_gitea_website: op read "op://Home network/xyzrcfuukvvg35dyyawz55d7j4/host address"
       plex_baseurl: op read "op://Songchro/Plex/hostname"
       plex_token: op read "op://Songchro/Plex/credential"
       public_gitea_username: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/3evxc47vgvyz4w65n6krlpq25u/user_name"
       sublime_text_license: op read "op://Adam/lewokobsx23vb6ncwce457sdvy/license key"
-      synology_api_account: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/glpg6ggd6hstlznvzdxfwbgzfm/username"
-      synology_api_password: op read "op://jrew5nqtk5aqdgupcoxqjuevwu/glpg6ggd6hstlznvzdxfwbgzfm/password"
+      synology_api_account: op read "op://Home network/cxo3hdywowt7btuoguvrqpe2l4/username"
+      synology_api_password: op read "op://Home network/cxo3hdywowt7btuoguvrqpe2l4/password"
     dotfiles:
       - d_bin
       - d_config_1Password

--- a/dotfiles/bin/op-sudopwd
+++ b/dotfiles/bin/op-sudopwd
@@ -4,4 +4,4 @@ if ! op whoami >/dev/null; then
   eval "$(op signin)"
 fi
 
-op read {{@@ host_password @@}}
+op read "{{@@ host_password @@}}"


### PR DESCRIPTION
- **Fix 1Password `op read` refs after vault moves**
- **Update `op-sudopwd` to handle space in `host_password`**
